### PR TITLE
Add "functional" header include

### DIFF
--- a/pq.hpp
+++ b/pq.hpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <map>
 #include <tuple>
+#include <functional>
 
 namespace pq {
     using std::string;


### PR DESCRIPTION
A `#include <functional>` statement is needed to use `std::function`.

For all of the things that I have worked on with this (which admittedly isn't many), I have found myself needing to add that statement just so that things could compile.